### PR TITLE
Swipe gesture recognizer for goBack() anywhere in the view

### DIFF
--- a/ForemWebView/ForemWebView.swift
+++ b/ForemWebView/ForemWebView.swift
@@ -69,6 +69,10 @@ open class ForemWebView: WKWebView {
         configuration.mediaTypesRequiringUserActionForPlayback = []
         allowsBackForwardNavigationGestures = true
         navigationDelegate = self
+
+        let gestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(swipeBack))
+        gestureRecognizer.direction = .right
+        self.addGestureRecognizer(gestureRecognizer)
     }
 
     // MARK: - Interface functions (open)
@@ -135,6 +139,14 @@ open class ForemWebView: WKWebView {
             if self.userData != userData {
                 self.userData = userData
             }
+        }
+    }
+
+    // Function that handles the swipe back from within the WebView for a more native fell navigation
+    @objc func swipeBack() {
+        guard let path = url?.path, foremInstance != nil else { return }
+        if path != "/" && canGoBack {
+            goBack()
         }
     }
 


### PR DESCRIPTION
From where I see it this approach has two problems (**A** and **B**):

**A)** When swiping back **from the edge** we are using the native `WKWebView` feature exposed by `allowsBackForwardNavigationGestures = true` ([here](https://github.com/forem/ForemWebView-ios/blob/main/ForemWebView/ForemWebView.swift#L70)). The custom swipe gesture added in this PR doesn't peek the previous page as we swipe, instead it only refreshes back immediately. 

Side by side comparison: https://share.getcloudapp.com/yAulplvK

After some initial research I don't think the WKWebView exposes an API to reproduce this behavior (simulate a "back Navigation" as if it were a native Navigation Controller popping a view). If this is not a problem we can stick with this for now, otherwise more research needs to be done in order to find a way to reproduce the better experience.

I was considering "relaying" the events from a `PanGestureRecognizer` that start anywhere on the screen, but editing the position of the taps to "simulate" an edge swipe. The intention is to try to "fool" the WKWebView implementation into thinking the swipe was actually coming from the edge, but I haven't had luck with this yet.

**B)**  After a swipe back that takes the user to the previous page, my immediate reaction is to start scrolling up/down the main feed. The problem is that the swipe gesture refreshed the page and now the Javascript in the main feed triggers a refresh with any swipe up/down.

https://share.getcloudapp.com/7Ku878Q1

This doesn't happen in the DEV Community app when manually going back (calling `webView.goBack()`) which leads me to believe there's something that can be fixed here to avoid this. Nevertheless it feels like finally tackling [forem/forem#7886](https://github.com/forem/forem/issues/7886) could fix this problem too