### PR TITLE
Adds support for ratio in image picker webkit message

### DIFF
--- a/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
+++ b/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
@@ -73,12 +73,15 @@ extension ForemWebView: WKScriptMessageHandler {
     // MARK: - Image Uploads
 
     // Builds, configures and returns an YPImagePicker
-    func imagePicker() -> YPImagePicker {
+    func imagePicker(_ ratio: String?) -> YPImagePicker {
         var config = YPImagePickerConfiguration()
         config.shouldSaveNewPicturesToAlbum = false
         config.startOnScreen = YPPickerScreen.library
         config.library.onlySquare = false
         config.library.isSquareByDefault = false
+        if let ratio = ratio, let rectangleRatio = Double(ratio) {
+            config.showsCrop = .rectangle(ratio: rectangleRatio)
+        }
         config.library.mediaType = YPlibraryMediaType.photo
         return YPImagePicker(configuration: config)
     }
@@ -87,7 +90,7 @@ extension ForemWebView: WKScriptMessageHandler {
     func handleImagePicker(_ message: [String: String]) {
         guard let targetElementId = message["id"] else { return }
 
-        let picker = imagePicker()
+        let picker = imagePicker(message["ratio"])
         picker.didFinishPicking { [unowned picker] items, _ in
             // Callback for when the native image picker process is completed by the user
             if let photo = items.singlePhoto {


### PR DESCRIPTION
This adds support for an extra param `ratio` to be sent in the bridge message. 

This way different image pickers can decide to send a `ratio` (the cover image picker should and a PR in `forem/forem` is coming soon). But at the same time, other image pickers that decide to omit this param would not encounter this restriction.

Closes #21 