### PR TITLE
Image Upload - Native Bridge fix

### DIFF
--- a/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
+++ b/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
@@ -117,10 +117,12 @@ extension ForemWebView: WKScriptMessageHandler {
         // React doesn't trigger `onChange` when updating the value of inputs
         // programmatically, so we are forced to dispatch the event manually
         let javascript = """
+                         {
                             let element = document.getElementById('\(targetElementId)');
                             element.value = `\(jsonString)`;
                             let changeEvent = new Event('input', { bubbles: true });
                             element.dispatchEvent(changeEvent);
+                         }
                          """
         
         evaluateJavaScript(javascript) { res, error in

--- a/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
+++ b/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
@@ -117,12 +117,16 @@ extension ForemWebView: WKScriptMessageHandler {
         // React doesn't trigger `onChange` when updating the value of inputs
         // programmatically, so we are forced to dispatch the event manually
         let javascript = """
-                            let element = document.getElementById('\(targetElementId)');
-                            element.value = `\(jsonString)`;
-                            let changeEvent = new Event('change', { bubbles: true });
-                            element.dispatchEvent(changeEvent);
+                         console.log("Injecting message")
+                         let element = document.getElementById('\(targetElementId)');
+                         console.log("Target element: ", element)
+                         element.value = `\(jsonString)`;
+                         console.log("Target element (again): ", element)
+                         let changeEvent = new Event('change', { bubbles: true });
+                         element.dispatchEvent(changeEvent);
                          """
-        evaluateJavaScript(wrappedJS(javascript)) { _, error in
+        evaluateJavaScript(javascript) { res, error in
+            print("WELP: \(String(describing: res)) - \(String(describing: error))")
             guard error == nil else {
                 print(error.debugDescription)
                 return

--- a/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
+++ b/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
@@ -118,11 +118,11 @@ extension ForemWebView: WKScriptMessageHandler {
         // programmatically, so we are forced to dispatch the event manually
         let javascript = """
                          console.log("Injecting message")
-                         let element = document.getElementById('\(targetElementId)');
+                         var element = document.getElementById('\(targetElementId)');
                          console.log("Target element: ", element)
                          element.value = `\(jsonString)`;
                          console.log("Target element (again): ", element)
-                         let changeEvent = new Event('change', { bubbles: true });
+                         var changeEvent = new Event('input', { bubbles: true });
                          element.dispatchEvent(changeEvent);
                          """
         evaluateJavaScript(javascript) { res, error in

--- a/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
+++ b/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
@@ -118,7 +118,7 @@ extension ForemWebView: WKScriptMessageHandler {
         // programmatically, so we are forced to dispatch the event manually
         let javascript = """
                          console.log("Injecting message")
-                         var element = document.getElementById('\(targetElementId)');
+                         var element = document.getElementById("\(targetElementId)");
                          console.log("Target element: ", element)
                          element.value = `\(jsonString)`;
                          console.log("Target element (again): ", element)

--- a/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
+++ b/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
@@ -117,18 +117,12 @@ extension ForemWebView: WKScriptMessageHandler {
         // React doesn't trigger `onChange` when updating the value of inputs
         // programmatically, so we are forced to dispatch the event manually
         let javascript = """
-                         console.log("Injecting message")
-                         var element = document.getElementById("\(targetElementId)");
-                         console.log("Target element: ", element)
-                         
+                            let element = document.getElementById('\(targetElementId)');
+                            element.value = `\(jsonString)`;
+                            let changeEvent = new Event('input', { bubbles: true });
+                            element.dispatchEvent(changeEvent);
                          """
         
-//        element.value = `\(jsonString)`;
-//        console.log("Target element (again): ", element)
-//        var changeEvent = new Event('input', { bubbles: true });
-//        element.dispatchEvent(changeEvent);
-        
-        javascript.replacingOccurrences(of: "\\\"", with: "")
         evaluateJavaScript(javascript) { res, error in
             print("WELP: \(String(describing: res)) - \(String(describing: error))")
             guard error == nil else {

--- a/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
+++ b/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
@@ -120,11 +120,15 @@ extension ForemWebView: WKScriptMessageHandler {
                          console.log("Injecting message")
                          var element = document.getElementById("\(targetElementId)");
                          console.log("Target element: ", element)
-                         element.value = `\(jsonString)`;
-                         console.log("Target element (again): ", element)
-                         var changeEvent = new Event('input', { bubbles: true });
-                         element.dispatchEvent(changeEvent);
+                         
                          """
+        
+//        element.value = `\(jsonString)`;
+//        console.log("Target element (again): ", element)
+//        var changeEvent = new Event('input', { bubbles: true });
+//        element.dispatchEvent(changeEvent);
+        
+        javascript.replacingOccurrences(of: "\\\"", with: "")
         evaluateJavaScript(javascript) { res, error in
             print("WELP: \(String(describing: res)) - \(String(describing: error))")
             guard error == nil else {

--- a/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
+++ b/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
@@ -125,8 +125,7 @@ extension ForemWebView: WKScriptMessageHandler {
                          }
                          """
         
-        evaluateJavaScript(javascript) { res, error in
-            print("WELP: \(String(describing: res)) - \(String(describing: error))")
+        evaluateJavaScript(wrappedJS(javascript)) { res, error in
             guard error == nil else {
                 print(error.debugDescription)
                 return

--- a/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
+++ b/Sources/ForemWebView/ForemWebView+WKScriptMessageHandler.swift
@@ -125,7 +125,7 @@ extension ForemWebView: WKScriptMessageHandler {
                          }
                          """
         
-        evaluateJavaScript(wrappedJS(javascript)) { res, error in
+        evaluateJavaScript(wrappedJS(javascript)) { _, error in
             guard error == nil else {
                 print(error.debugDescription)
                 return


### PR DESCRIPTION
Fixes a JS problem in `injectImageMessage` where Preact no longer accepts `change` as an event that will trigger `onChange` callbacks. We need to use `input` instead. It appears to be related with a JS dependency that changed this behavior.