### PR TITLE
Implements WKUIDelegate

### DIFF
--- a/Sources/ForemWebView/ForemWebView+WKUIDelegate.swift
+++ b/Sources/ForemWebView/ForemWebView+WKUIDelegate.swift
@@ -1,0 +1,56 @@
+#if os(iOS)
+
+import UIKit
+import WebKit
+
+extension ForemWebView: WKUIDelegate {
+    public func webView(_ webView: WKWebView,
+                        runJavaScriptConfirmPanelWithMessage message: String,
+                        initiatedByFrame frame: WKFrameInfo,
+                        completionHandler: @escaping (Bool) -> Void) {
+        
+        let alertController = UIAlertController(title: nil,
+                                                message: message,
+                                                preferredStyle: .alert)
+        
+        alertController.addAction(
+            UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel) { _ in
+                completionHandler(false)
+            }
+        )
+        
+        alertController.addAction(
+            UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default) { _ in
+                completionHandler(true)
+            }
+        )
+        
+        // Use 'foremWebViewDelegate' as the 'pivot' ViewController to present the native picker
+        if let delegateViewController = foremWebViewDelegate as? UIViewController {
+            delegateViewController.present(alertController, animated: true, completion: nil)
+        }
+    }
+    
+    public func webView(_ webView: WKWebView,
+                        runJavaScriptAlertPanelWithMessage message: String,
+                        initiatedByFrame frame: WKFrameInfo,
+                        completionHandler: @escaping () -> Void) {
+        
+        let alertController = UIAlertController(title: nil,
+                                                message: message,
+                                                preferredStyle: .alert)
+        
+        alertController.addAction(
+            UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default) { _ in
+                completionHandler()
+            }
+        )
+        
+        // Use 'foremWebViewDelegate' as the 'pivot' ViewController to present the native picker
+        if let delegateViewController = foremWebViewDelegate as? UIViewController {
+            delegateViewController.present(alertController, animated: true, completion: nil)
+        }
+    }
+}
+
+#endif

--- a/Sources/ForemWebView/ForemWebView.swift
+++ b/Sources/ForemWebView/ForemWebView.swift
@@ -78,6 +78,7 @@ open class ForemWebView: WKWebView {
         configuration.mediaTypesRequiringUserActionForPlayback = []
         allowsBackForwardNavigationGestures = true
         navigationDelegate = self
+        uiDelegate = self
     }
 
     // MARK: - Interface functions (open)


### PR DESCRIPTION

After a more thorough look into `forem/forem` codebase I found the following places where we use `window.confirm` or `window.alert` (we don't use `window.prompt`):

![Screen Shot 2021-05-21 at 08 17 51](https://user-images.githubusercontent.com/6045239/119152797-dd980200-ba0d-11eb-9554-5adea1eaa42a.png)

![Screen Shot 2021-05-21 at 08 27 39](https://user-images.githubusercontent.com/6045239/119153367-6b73ed00-ba0e-11eb-8e31-d636bd4176d5.png)

![Screen Shot 2021-05-21 at 08 21 24](https://user-images.githubusercontent.com/6045239/119152814-e12b8900-ba0d-11eb-8a22-7afc07e444f2.png)

This PR makes the `ForemWebView` self sufficient in this regard, meaning that consumers of the Framework don't need to worry about implementing the delegate.