### PR TITLE
Navigator API availability fix without reload

### DIFF
--- a/Sources/ForemWebView/ForemWebView+WKNavigationDelegate.swift
+++ b/Sources/ForemWebView/ForemWebView+WKNavigationDelegate.swift
@@ -14,10 +14,10 @@ extension ForemWebView: WKNavigationDelegate {
         foremWebViewDelegate?.didFinishNavigation()
         
         // Create one timer that will make sure we periodically fetch the user data from the body element
-        guard userDataTimer == nil else { return }
-        userDataTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
-            self.updateUserData()
-        }
+//        guard userDataTimer == nil else { return }
+//        userDataTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
+//            self.updateUserData()
+//        }
     }
 
     public func webView(_ webView: WKWebView,

--- a/Sources/ForemWebView/ForemWebView+WKNavigationDelegate.swift
+++ b/Sources/ForemWebView/ForemWebView+WKNavigationDelegate.swift
@@ -14,10 +14,10 @@ extension ForemWebView: WKNavigationDelegate {
         foremWebViewDelegate?.didFinishNavigation()
         
         // Create one timer that will make sure we periodically fetch the user data from the body element
-//        guard userDataTimer == nil else { return }
-//        userDataTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
-//            self.updateUserData()
-//        }
+        guard userDataTimer == nil else { return }
+        userDataTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
+            self.updateUserData()
+        }
     }
 
     public func webView(_ webView: WKWebView,

--- a/Sources/ForemWebView/ForemWebView.swift
+++ b/Sources/ForemWebView/ForemWebView.swift
@@ -45,27 +45,14 @@ open class ForemWebView: WKWebView {
     }
 
     public override init(frame: CGRect, configuration: WKWebViewConfiguration) {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        let frameworkIdentifier = "ForemWebView/\(version ?? "0.0")"
+        configuration.applicationNameForUserAgent = frameworkIdentifier
         super.init(frame: frame, configuration: configuration)
         setupWebView()
     }
 
     func setupWebView() {
-//        evaluateJavaScript("navigator.userAgent") { (result, error) in
-//            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-//            let frameworkIdentifier = "ForemWebView/\(version ?? "0.0")"
-//            if let result = result {
-//                self.customUserAgent = "\(result) \(frameworkIdentifier)"
-//            } else {
-//                print("Error: \(String(describing: error?.localizedDescription))")
-//                print("Unable to extend the base UserAgent. Will default to '\(frameworkIdentifier)'")
-//                self.customUserAgent = frameworkIdentifier
-//            }
-//        }
-        
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-        let frameworkIdentifier = "ForemWebView/\(version ?? "0.0")"
-        
-        configuration.applicationNameForUserAgent = frameworkIdentifier
         configuration.userContentController.add(self, name: "haptic")
         configuration.userContentController.add(self, name: "body")
         configuration.userContentController.add(self, name: "podcast")
@@ -202,32 +189,11 @@ open class ForemWebView: WKWebView {
 
             do {
                 self.foremInstance = try JSONDecoder().decode(ForemInstanceMetadata.self, from: Data(jsonString.utf8))
-//                self.ensureCustomUserAgent()
             } catch {
                 print("Error parsing Forem Instance Metadata: \(error)")
             }
         }
     }
-    
-    // Helper function that will customize the UserAgent so the web context will detect we are
-    // navigating in a ForemWebView. This will allow us to make use of native bridge features
-//    func ensureCustomUserAgent() {
-//        // This approach maintains a UserAgent format that most servers & third party services will see us
-//        // as non-malicious. Example: reCaptcha may take into account a "familiarly formatted" as more
-//        // trustworthy compared to bots thay may use more plain strings like "Forem"/"DEV"/etc
-//        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
-//        evaluateJavaScript("navigator.userAgent") { (result, error) in
-//            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-//            let frameworkIdentifier = "ForemWebView/\(version ?? "0.0")"
-//            if let result = result {
-//                self.customUserAgent = "\(result) \(frameworkIdentifier)"
-//            } else {
-//                print("Error: \(String(describing: error?.localizedDescription))")
-//                print("Unable to extend the base UserAgent. Will default to '\(frameworkIdentifier)'")
-//                self.customUserAgent = frameworkIdentifier
-//            }
-//        }
-//    }
 
     // Helper function to close the Podcast Player UI in the DOM
     func closePodcastUI() {

--- a/Sources/ForemWebView/ForemWebView.swift
+++ b/Sources/ForemWebView/ForemWebView.swift
@@ -54,17 +54,17 @@ open class ForemWebView: WKWebView {
         // as non-malicious. Example: reCaptcha may take into account a "familiarly formatted" as more
         // trustworthy compared to bots thay may use more plain strings like "Forem"/"DEV"/etc
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
-        evaluateJavaScript("navigator.userAgent") { (result, error) in
-            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-            let frameworkIdentifier = "ForemWebView/\(version ?? "0.0")"
-            if let result = result {
-                self.customUserAgent = "\(result) \(frameworkIdentifier)"
-            } else {
-                print("Error: \(String(describing: error?.localizedDescription))")
-                print("Unable to extend the base UserAgent. Will default to '\(frameworkIdentifier)'")
-                self.customUserAgent = frameworkIdentifier
-            }
-        }
+//        evaluateJavaScript("navigator.userAgent") { (result, error) in
+//            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+//            let frameworkIdentifier = "ForemWebView/\(version ?? "0.0")"
+//            if let result = result {
+//                self.customUserAgent = "\(result) \(frameworkIdentifier)"
+//            } else {
+//                print("Error: \(String(describing: error?.localizedDescription))")
+//                print("Unable to extend the base UserAgent. Will default to '\(frameworkIdentifier)'")
+//                self.customUserAgent = frameworkIdentifier
+//            }
+//        }
 
         configuration.userContentController.add(self, name: "haptic")
         configuration.userContentController.add(self, name: "body")

--- a/Sources/ForemWebView/ForemWebView.swift
+++ b/Sources/ForemWebView/ForemWebView.swift
@@ -40,16 +40,26 @@ open class ForemWebView: WKWebView {
     }()
 
     required public init?(coder: NSCoder) {
-        super.init(coder: coder)
+        let customConfig = ForemWebView.configuration()
+        super.init(frame: UIScreen.main.bounds, configuration: customConfig)
         setupWebView()
     }
 
     public override init(frame: CGRect, configuration: WKWebViewConfiguration) {
+        let customConfig = ForemWebView.configuration(base: configuration)
+        super.init(frame: frame, configuration: customConfig)
+        setupWebView()
+    }
+    
+    // Static method that helps recreate a custom configuration required before instantiation (init methods)
+    class func configuration(base configuration: WKWebViewConfiguration = WKWebViewConfiguration()) -> WKWebViewConfiguration {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
         let frameworkIdentifier = "ForemWebView/\(version ?? "0.0")"
         configuration.applicationNameForUserAgent = frameworkIdentifier
-        super.init(frame: frame, configuration: configuration)
-        setupWebView()
+
+        configuration.allowsInlineMediaPlayback = true
+        configuration.mediaTypesRequiringUserActionForPlayback = []
+        return configuration
     }
 
     func setupWebView() {
@@ -60,9 +70,6 @@ open class ForemWebView: WKWebView {
         if AVPictureInPictureController.isPictureInPictureSupported() {
             configuration.userContentController.add(self, name: "video")
         }
-
-        configuration.allowsInlineMediaPlayback = true
-        configuration.mediaTypesRequiringUserActionForPlayback = []
         allowsBackForwardNavigationGestures = true
         navigationDelegate = self
         uiDelegate = self

--- a/Sources/ForemWebView/ForemWebView.swift
+++ b/Sources/ForemWebView/ForemWebView.swift
@@ -50,6 +50,22 @@ open class ForemWebView: WKWebView {
     }
 
     func setupWebView() {
+//        evaluateJavaScript("navigator.userAgent") { (result, error) in
+//            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+//            let frameworkIdentifier = "ForemWebView/\(version ?? "0.0")"
+//            if let result = result {
+//                self.customUserAgent = "\(result) \(frameworkIdentifier)"
+//            } else {
+//                print("Error: \(String(describing: error?.localizedDescription))")
+//                print("Unable to extend the base UserAgent. Will default to '\(frameworkIdentifier)'")
+//                self.customUserAgent = frameworkIdentifier
+//            }
+//        }
+        
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        let frameworkIdentifier = "ForemWebView/\(version ?? "0.0")"
+        
+        configuration.applicationNameForUserAgent = frameworkIdentifier
         configuration.userContentController.add(self, name: "haptic")
         configuration.userContentController.add(self, name: "body")
         configuration.userContentController.add(self, name: "podcast")
@@ -186,7 +202,7 @@ open class ForemWebView: WKWebView {
 
             do {
                 self.foremInstance = try JSONDecoder().decode(ForemInstanceMetadata.self, from: Data(jsonString.utf8))
-                self.ensureCustomUserAgent()
+//                self.ensureCustomUserAgent()
             } catch {
                 print("Error parsing Forem Instance Metadata: \(error)")
             }
@@ -195,23 +211,23 @@ open class ForemWebView: WKWebView {
     
     // Helper function that will customize the UserAgent so the web context will detect we are
     // navigating in a ForemWebView. This will allow us to make use of native bridge features
-    func ensureCustomUserAgent() {
-        // This approach maintains a UserAgent format that most servers & third party services will see us
-        // as non-malicious. Example: reCaptcha may take into account a "familiarly formatted" as more
-        // trustworthy compared to bots thay may use more plain strings like "Forem"/"DEV"/etc
-        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
-        evaluateJavaScript("navigator.userAgent") { (result, error) in
-            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-            let frameworkIdentifier = "ForemWebView/\(version ?? "0.0")"
-            if let result = result {
-                self.customUserAgent = "\(result) \(frameworkIdentifier)"
-            } else {
-                print("Error: \(String(describing: error?.localizedDescription))")
-                print("Unable to extend the base UserAgent. Will default to '\(frameworkIdentifier)'")
-                self.customUserAgent = frameworkIdentifier
-            }
-        }
-    }
+//    func ensureCustomUserAgent() {
+//        // This approach maintains a UserAgent format that most servers & third party services will see us
+//        // as non-malicious. Example: reCaptcha may take into account a "familiarly formatted" as more
+//        // trustworthy compared to bots thay may use more plain strings like "Forem"/"DEV"/etc
+//        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+//        evaluateJavaScript("navigator.userAgent") { (result, error) in
+//            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+//            let frameworkIdentifier = "ForemWebView/\(version ?? "0.0")"
+//            if let result = result {
+//                self.customUserAgent = "\(result) \(frameworkIdentifier)"
+//            } else {
+//                print("Error: \(String(describing: error?.localizedDescription))")
+//                print("Unable to extend the base UserAgent. Will default to '\(frameworkIdentifier)'")
+//                self.customUserAgent = frameworkIdentifier
+//            }
+//        }
+//    }
 
     // Helper function to close the Podcast Player UI in the DOM
     func closePodcastUI() {

--- a/Sources/ForemWebView/ForemWebView.swift
+++ b/Sources/ForemWebView/ForemWebView.swift
@@ -51,7 +51,7 @@ open class ForemWebView: WKWebView {
         setupWebView()
     }
     
-    // Static method that helps recreate a custom configuration required before instantiation (init methods)
+    // Helper function that helps recreate a custom configuration required before instantiation (init methods)
     class func configuration(base configuration: WKWebViewConfiguration = WKWebViewConfiguration()) -> WKWebViewConfiguration {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
         let frameworkIdentifier = "ForemWebView/\(version ?? "0.0")"

--- a/Tests/ForemWebViewTests/ForemWebViewTests.swift
+++ b/Tests/ForemWebViewTests/ForemWebViewTests.swift
@@ -41,9 +41,12 @@ final class ForemWebViewTests: XCTestCase {
         let promise = expectation(description: "Custom UserAgent")
         // On top of the expectation it turns out we need to give the webView some time to load/process the HTML string
         DispatchQueue.main.asyncAfter(deadline: .now() + asyncAfter) {
-            let userAgentCheck = webView.customUserAgent?.contains("ForemWebView")
-            XCTAssertTrue(userAgentCheck ?? false, "The UserAgent contains 'ForemWebView' for metrics")
-            promise.fulfill()
+            webView.evaluateJavaScript("navigator.userAgent") { (result, error) in
+                guard let userAgent = result as? String else { return }
+                let userAgentCheck = userAgent.contains("ForemWebView")
+                XCTAssertTrue(userAgentCheck, "The UserAgent contains 'ForemWebView' for identification purposes")
+                promise.fulfill()
+            }
         }
         wait(for: [promise], timeout: timeout)
     }


### PR DESCRIPTION
This PR changes the way the custom UserAgent is registered on the `ForemWebView` instance.

Using `self.customUserAgent` to assign a custom UserAgent was causing issues. This change now relies on `applicationNameForUserAgent` instead and it makes sure this configuration is set before the `WKWebView` is instantiated (otherwise we ran into other problems).

Closes https://github.com/forem/forem-ios/issues/60