### PR TITLE
Change unowned self with weak self

### DIFF
--- a/Sources/ForemWebView/ForemWebView+WKNavigationDelegate.swift
+++ b/Sources/ForemWebView/ForemWebView+WKNavigationDelegate.swift
@@ -12,9 +12,9 @@ extension ForemWebView: WKNavigationDelegate {
             scrollView.setContentOffset(cachedState.scrollOffset, animated: false)
             UIView.animate(withDuration: 0.5) {
                 cachedState.snapshot.alpha = 0
-            } completion: { [unowned self] _ in
+            } completion: { [weak self] _ in
                 cachedState.snapshot.removeFromSuperview()
-                self.cachedState = nil
+                self?.cachedState = nil
             }
         }
         


### PR DESCRIPTION
Based on the use case in Forem iOS app, when someone quickly swipes through instances the following happens:
1. There's a chance the WebView gets initialized using a cached state
2. The navigation is requested and when it completes then this animation gets kicked off
   - The animation consists of hiding the snapshot by setting `alpha = 0`
4. When the animation finishes the completion callback is executed, but there's a chance (if the user is swiping relatively quickly) that by the time this callback executes the webview (`self`) is already de-initialized.
   - This happens when the webview falls out of the window of webviews we keep in memory before the animation finishes

Because of this scenario it's better to use `weak` than `unowned`, because it gives us null safety by considering `self` optional.