### PR TITLE
Reorder logic to only allow accepted links

### DIFF
--- a/Sources/ForemWebView/ForemWebView+WKNavigationDelegate.swift
+++ b/Sources/ForemWebView/ForemWebView+WKNavigationDelegate.swift
@@ -43,7 +43,16 @@ extension ForemWebView: WKNavigationDelegate {
             return
         }
         let policy = navigationPolicy(url: url, navigationType: navigationAction.navigationType)
-        decisionHandler(policy)
+        
+        // target="_blank" normal navigation won't work and in order for the webview to follow
+        // these links (specially within an iframe) requires us to capture the navigation and
+        // `.cancel` it, then manually loading the URL.
+        if policy == .allow && navigationAction.targetFrame != nil {
+            decisionHandler(.cancel)
+            load(url.absoluteString)
+        } else {
+            decisionHandler(policy)
+        }
     }
     
     public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {

--- a/Sources/ForemWebView/ForemWebView+WKNavigationDelegate.swift
+++ b/Sources/ForemWebView/ForemWebView+WKNavigationDelegate.swift
@@ -47,7 +47,7 @@ extension ForemWebView: WKNavigationDelegate {
         // target="_blank" normal navigation won't work and in order for the webview to follow
         // these links (specially within an iframe) requires us to capture the navigation and
         // `.cancel` it, then manually loading the URL.
-        if policy == .allow && navigationAction.targetFrame != nil {
+        if policy == .allow && navigationAction.targetFrame == nil {
             decisionHandler(.cancel)
             load(url.absoluteString)
         } else {


### PR DESCRIPTION
External links were "being swallowed" so this takes the policy into account. 

The difference is that here we're only capturing the `target="_blank"` if the policy returned is `.allow`