### PR TITLE
Use YPImagePicker SPM versioned releases

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
         "state": {
           "branch": null,
-          "revision": "eaf6e622dd41b07b251d8f01752eab31bc811493",
-          "version": "5.4.1"
+          "revision": "d120af1e8638c7da36c8481fd61a66c0c08dc4fc",
+          "version": "5.4.4"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Alamofire/AlamofireImage.git",
         "state": {
           "branch": null,
-          "revision": "3e8edbeb75227f8542aa87f90240cf0424d6362f",
-          "version": "4.1.0"
+          "revision": "98cbb00ce0ec5fc8e52a5b50a6bfc08d3e5aee10",
+          "version": "4.2.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/Yummypets/YPImagePicker",
         "state": {
           "branch": null,
-          "revision": "2cf2d150bb0861f2079bc44b56c17aabf5e5d5aa",
-          "version": null
+          "revision": "f12f5d3b31292da5966c08a4918a04959b3de63d",
+          "version": "5.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Yummypets/YPImagePicker", .revision("2cf2d150bb0861f2079bc44b56c17aabf5e5d5aa")),
+        .package(url: "https://github.com/Yummypets/YPImagePicker", .upToNextMajor(from: "5.0.0")),
         .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.4.0"),
         .package(url: "https://github.com/Alamofire/AlamofireImage.git", from: "4.1.0"),
     ],


### PR DESCRIPTION
With the [`5.0.0` release](https://github.com/Yummypets/YPImagePicker/releases/tag/5.0.0) of YPImagePicker we can go back to properly versioned releases.

In the past we were forced to reference a SPM branch or specific commit because it wasn't supported. This was a problem because if one of our dependencies doesn't have a versioned release then projects that depends on us won't be able to reference our versioned releases.