### PR TITLE
Use meta tag CSRF and not window.csrfToken

### DIFF
--- a/Sources/ForemWebView/ForemWebView.swift
+++ b/Sources/ForemWebView/ForemWebView.swift
@@ -138,7 +138,8 @@ open class ForemWebView: WKWebView {
 
     // Function that fetches the CSRF Token required for direct interaction with the Forem servers
     func fetchCSRF(completion: @escaping (String?) -> Void) {
-        evaluateJavaScript(wrappedJS("window.csrfToken")) { result, error in
+        let javascript = "document.querySelector(`meta[name='csrf-token']`)?.value"
+        evaluateJavaScript(wrappedJS(javascript)) { result, error in
             if let error = error {
                 print("Unable to fetch CSRF Token: \(error.localizedDescription)")
                 completion(nil)

--- a/Sources/ForemWebView/ForemWebView.swift
+++ b/Sources/ForemWebView/ForemWebView.swift
@@ -138,7 +138,7 @@ open class ForemWebView: WKWebView {
 
     // Function that fetches the CSRF Token required for direct interaction with the Forem servers
     func fetchCSRF(completion: @escaping (String?) -> Void) {
-        let javascript = "document.querySelector(`meta[name='csrf-token']`)?.value"
+        let javascript = "document.querySelector(`meta[name='csrf-token']`)?.content"
         evaluateJavaScript(wrappedJS(javascript)) { result, error in
             if let error = error {
                 print("Unable to fetch CSRF Token: \(error.localizedDescription)")


### PR DESCRIPTION
I noticed that `window.csrfToken` wasn't working properly as I was seeing some Invalid CSRF Token when making JSON requests while debugging on my device.

This PR changes the way we fetch the CSRF token from the JS/DOM context. It's now relying on what [this `forem/forem` utility](https://github.com/forem/forem/blob/main/app/javascript/utilities/getUserDataAndCsrfToken.js#L2) uses to get the CSRF token on `forem/forem` FE codebase.